### PR TITLE
click logo after login

### DIFF
--- a/web/src/components/Nav.vue
+++ b/web/src/components/Nav.vue
@@ -1,6 +1,6 @@
 <template>
     <div id="nav" class="cont">
-        <router-link class="home-logo" to="/" >
+        <router-link class="home-logo" :to="this.$store.state.logged ? '/dashboard' : '/'" >
             <img src="https://svgshare.com/i/J_x.svg" alt="iban.im">
         </router-link>
     </div>


### PR DESCRIPTION
Clicking on the logo after login, redirects to '/dashboard' instead of '/'.